### PR TITLE
Clean up build.yml by removing commented-out environment variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,6 @@ concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: true
 
-# env:
-#   DOCKER_BUILDKIT: 1
-#   COMPOSE_DOCKER_CLI_BUILD: 1
-
 jobs:
   deploy-production:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Remove unnecessary commented-out environment variables from build.yml for a cleaner configuration.