### PR TITLE
Add FbData interface and update CreateOrderBody for Facebook tracking

### DIFF
--- a/apps/site-2026/src/api/customerApi.ts
+++ b/apps/site-2026/src/api/customerApi.ts
@@ -89,13 +89,19 @@ export interface CustomerOrder {
   tickets?: TicketItem[];
 }
 
+export interface FbData {
+  pixel_id: string;
+  fbp?: string;
+  fbc?: string;
+  fbclid?: string;
+  test_event_code?: string;
+}
+
 export interface CreateOrderBody {
   type_order: 'basic' | 'discounted' | 'family';
   lang: string;
   tickets: Array<{ name: string; send_email: boolean; email?: string }>;
-  fbp?: string;
-  fbc?: string;
-  fbclid?: string;
+  fb?: FbData;
 }
 
 export interface CreateOrderResponse {

--- a/apps/site-2026/src/components/Contribute.tsx
+++ b/apps/site-2026/src/components/Contribute.tsx
@@ -11,6 +11,7 @@ import {
   getStoredName,
   CreateOrderBody,
   CustomerOrder,
+  FbData,
 } from '../api/customerApi';
 import AuthCard from './contribute/AuthCard';
 import PasswordResetCard from './contribute/PasswordResetCard';
@@ -340,7 +341,14 @@ export default function Contribute({ autoOpenTickets = true }: ContributeProps) 
     setOrderError('');
     setOrderLoading(true);
     try {
-      const { fbp, fbc, fbclid } = getFbTrackingData();
+      const { pixel_id, fbp, fbc, fbclid, test_event_code } = getFbTrackingData();
+      const fb: FbData = {
+        pixel_id,
+        ...(fbp ? { fbp } : {}),
+        ...(fbc ? { fbc } : {}),
+        ...(fbclid ? { fbclid } : {}),
+        ...(test_event_code ? { test_event_code } : {}),
+      };
       const body: CreateOrderBody = {
         type_order: orderType,
         lang: langForApi(i18n.language),
@@ -349,9 +357,7 @@ export default function Contribute({ autoOpenTickets = true }: ContributeProps) 
           send_email: orderSendEmail,
           ...(orderSendEmail && orderEmail && orderEmail !== userEmail ? { email: orderEmail } : {}),
         })),
-        ...(fbp ? { fbp } : {}),
-        ...(fbc ? { fbc } : {}),
-        ...(fbclid ? { fbclid } : {}),
+        fb,
       };
       const res = await customerApi.createOrder(body);
       if (res.invoice_url) {

--- a/apps/site-2026/src/components/GTMLoader.tsx
+++ b/apps/site-2026/src/components/GTMLoader.tsx
@@ -1,10 +1,8 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { saveFbclid } from '../utils/fbTracking';
+import { saveFbclid, META_PIXEL_ID } from '../utils/fbTracking';
 
 const GTM_ID = 'GTM-WGJVLZWW';
-// const META_PIXEL_ID = '1549796436578301';
-const META_PIXEL_ID = '1220572229100482'; // Stratulat
 
 /** GTM does not load on all pages /contribute* */
 function isGtmBlocked(pathname: string): boolean {

--- a/apps/site-2026/src/utils/fbTracking.ts
+++ b/apps/site-2026/src/utils/fbTracking.ts
@@ -1,33 +1,50 @@
+export const META_PIXEL_ID = '1220572229100482'; // Stratulat
+// const META_PIXEL_ID = '1549796436578301'; // Graffex
+
 const FBCLID_KEY = 'fb_clid';
 
-/** Saves fbclid to localStorage. An empty value is ignored. */
+/** Сохраняет fbclid в localStorage. Пустое значение игнорируется. */
 export function saveFbclid(value: string): void {
-    if (value) {
-        localStorage.setItem(FBCLID_KEY, value);
-    }
+  if (value) {
+    localStorage.setItem(FBCLID_KEY, value);
+  }
 }
 
 export function getStoredFbclid(): string | null {
-    return localStorage.getItem(FBCLID_KEY);
+  return localStorage.getItem(FBCLID_KEY);
 }
 
 function getCookie(name: string): string | undefined {
-    return document.cookie
-        .split('; ')
-        .find(c => c.startsWith(`${name}=`))
-        ?.split('=')[1];
+  return document.cookie
+    .split('; ')
+    .find(c => c.startsWith(`${name}=`))
+    ?.split('=')[1];
+}
+
+export interface FbTrackingData {
+  pixel_id: string;
+  fbp?: string;
+  fbc?: string;
+  fbclid?: string;
+  /** Только для тестирования через Meta Events Manager. Не использовать в продакшн. */
+  test_event_code?: string;
 }
 
 /**
-  * Returns data for Meta CAPI:
-  * - fbp — from the _fbp cookie (set by the browser pixel)
-  * - fbc — from the _fbc cookie (set when clicking through from a Meta ad)
-  * - fbclid — saved from the URL on the first visit
-  */
-export function getFbTrackingData(): { fbp?: string; fbc?: string; fbclid?: string } {
-    return {
-        fbp: getCookie('_fbp') || undefined,
-        fbc: getCookie('_fbc') || undefined,
-        fbclid: getStoredFbclid() || undefined,
-    };
+ * Собирает данные для Meta CAPI:
+ * - pixel_id — идентификатор пикселя
+ * - fbp — из cookie _fbp (устанавливается браузерным пикселем)
+ * - fbc — из cookie _fbc (устанавливается при переходе с рекламы Meta)
+ * - fbclid — сохранённый из URL при первом визите
+ * - test_event_code — из REACT_APP_META_TEST_EVENT_CODE (только для тестов)
+ */
+export function getFbTrackingData(): FbTrackingData {
+  const testEventCode = process.env.REACT_APP_META_TEST_EVENT_CODE;
+  return {
+    pixel_id: META_PIXEL_ID,
+    fbp: getCookie('_fbp') || undefined,
+    fbc: getCookie('_fbc') || undefined,
+    fbclid: getStoredFbclid() || undefined,
+    ...(testEventCode ? { test_event_code: testEventCode } : {}),
+  };
 }


### PR DESCRIPTION
Introduce the FbData interface to encapsulate Facebook tracking data and modify CreateOrderBody to include this new structure. This change enhances the order creation process by integrating additional tracking information.