### PR TITLE
Enhance Facebook tracking integration

### DIFF
--- a/apps/site-2026/src/api/customerApi.ts
+++ b/apps/site-2026/src/api/customerApi.ts
@@ -94,7 +94,14 @@ export interface FbData {
   fbp?: string;
   fbc?: string;
   fbclid?: string;
-  test_event_code?: string;
+}
+
+export interface RegisterFbParams {
+  fb_pixel_id?: string;
+  event_source_url?: string;
+  fbp?: string;
+  fbc?: string;
+  fbclid?: string;
 }
 
 export interface CreateOrderBody {
@@ -132,8 +139,9 @@ export interface PasswordResetConfirmBody {
 }
 
 export const customerApi = {
-  register: (email: string, password: string, lang: string, name?: string) =>
-    apiFetch<AuthResponse>('POST', '/register', { email, password, lang, ...(name ? { name } : {}) }),
+  register: (email: string, password: string, lang: string, name?: string, fb?: RegisterFbParams) =>
+    apiFetch<AuthResponse>('POST', '/register', { email, password, lang, ...(name ? { name } : {}), ...fb }),
+
 
   login: (email: string, password: string) =>
     apiFetch<AuthResponse>('POST', '/auth', { email, password }),

--- a/apps/site-2026/src/components/Contribute.tsx
+++ b/apps/site-2026/src/components/Contribute.tsx
@@ -12,6 +12,7 @@ import {
   CreateOrderBody,
   CustomerOrder,
   FbData,
+  RegisterFbParams,
 } from '../api/customerApi';
 import AuthCard from './contribute/AuthCard';
 import PasswordResetCard from './contribute/PasswordResetCard';
@@ -292,9 +293,20 @@ export default function Contribute({ autoOpenTickets = true }: ContributeProps) 
     setShowForgotPassword(false);
     setAuthLoading(true);
     try {
-      const res = authMode === 'login'
-        ? await customerApi.login(authEmail, authPassword)
-        : await customerApi.register(authEmail, authPassword, langForApi(i18n.language), authName || undefined);
+      let res;
+      if (authMode === 'login') {
+        res = await customerApi.login(authEmail, authPassword);
+      } else {
+        const { pixel_id, fbp, fbc, fbclid } = getFbTrackingData();
+        const fb: RegisterFbParams = {
+          fb_pixel_id: pixel_id,
+          event_source_url: window.location.href,
+          ...(fbp ? { fbp } : {}),
+          ...(fbc ? { fbc } : {}),
+          ...(fbclid ? { fbclid } : {}),
+        };
+        res = await customerApi.register(authEmail, authPassword, langForApi(i18n.language), authName || undefined, fb);
+      }
       const name = res.name || '';
       saveSession(res.access_token, res.email, name);
       setToken(res.access_token);
@@ -341,13 +353,12 @@ export default function Contribute({ autoOpenTickets = true }: ContributeProps) 
     setOrderError('');
     setOrderLoading(true);
     try {
-      const { pixel_id, fbp, fbc, fbclid, test_event_code } = getFbTrackingData();
+      const { pixel_id, fbp, fbc, fbclid } = getFbTrackingData();
       const fb: FbData = {
         pixel_id,
         ...(fbp ? { fbp } : {}),
         ...(fbc ? { fbc } : {}),
         ...(fbclid ? { fbclid } : {}),
-        ...(test_event_code ? { test_event_code } : {}),
       };
       const body: CreateOrderBody = {
         type_order: orderType,

--- a/apps/site-2026/src/utils/fbTracking.ts
+++ b/apps/site-2026/src/utils/fbTracking.ts
@@ -37,12 +37,10 @@ export interface FbTrackingData {
   * - test_event_code — from REACT_APP_META_TEST_EVENT_CODE (for tests only)
   */
 export function getFbTrackingData(): FbTrackingData {
-  const testEventCode = process.env.REACT_APP_META_TEST_EVENT_CODE;
   return {
     pixel_id: META_PIXEL_ID,
     fbp: getCookie('_fbp') || undefined,
     fbc: getCookie('_fbc') || undefined,
     fbclid: getStoredFbclid() || undefined,
-    ...(testEventCode ? { test_event_code: testEventCode } : {}),
   };
 }


### PR DESCRIPTION
Improve Facebook tracking by adding `RegisterFbParams` and updating the `register` method in the `customerApi` to include Facebook tracking data during user registration. This enhancement allows for better tracking of user interactions through Facebook.