### PR TITLE
feat(ui): add an anti-spam honeypot field to the feedback form

### DIFF
--- a/apps/site-2026/src/api/feedbackApi.ts
+++ b/apps/site-2026/src/api/feedbackApi.ts
@@ -20,6 +20,12 @@ export interface FeedbackPayload extends FeedbackSubmitData {
   languages: string[];
   networkType?: string;
   fillTimeMs: number; // time spent filling the form
+  /**
+   * Honeypot: a trap field hidden from the user.
+   * A living person always has an empty line; if filled, it means a bot.
+   * The decision on what to do with such a request is made by the backend.
+   */
+  name: string;
 }
 
 export async function submitFeedbackToBackend(payload: FeedbackPayload): Promise<void> {

--- a/apps/site-2026/src/components/Feedback.tsx
+++ b/apps/site-2026/src/components/Feedback.tsx
@@ -32,6 +32,7 @@ export default function Feedback() {
     selectedHelp: new Set(),
     contact: "",
     q10Answer: "",
+    honeypot: "",
   });
 
   const [currentStep, setCurrentStep] = useState(1);
@@ -78,6 +79,7 @@ export default function Feedback() {
         languages: deviceStats.languages,
         networkType: deviceStats.networkType || "unknown",
         fillTimeMs,
+        name: state.honeypot,
       });
 
       // Redirect to thank you page on success
@@ -137,6 +139,7 @@ export default function Feedback() {
               }}
               onContactChange={(value) => setState({ ...state, contact: value })}
               onQ10Change={(value) => setState({ ...state, q10Answer: value })}
+              onHoneypotChange={(value) => setState({ ...state, honeypot: value })}
               onSubmit={handleSubmit}
               isSubmitting={isSubmitting}
               t={t}
@@ -168,6 +171,7 @@ export default function Feedback() {
             }}
             onContactChange={(value) => setState({ ...state, contact: value })}
             onQ10Change={(value) => setState({ ...state, q10Answer: value })}
+            onHoneypotChange={(value) => setState({ ...state, honeypot: value })}
             onSubmit={handleSubmit}
             isSubmitting={isSubmitting}
             t={t}
@@ -200,6 +204,7 @@ export default function Feedback() {
             }}
             onContactChange={(value) => setState({ ...state, contact: value })}
             onQ10Change={(value) => setState({ ...state, q10Answer: value })}
+            onHoneypotChange={(value) => setState({ ...state, honeypot: value })}
             onSubmit={handleSubmit}
             isSubmitting={isSubmitting}
             t={t}

--- a/apps/site-2026/src/components/Feedback/AccordionVariant.tsx
+++ b/apps/site-2026/src/components/Feedback/AccordionVariant.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { VariantProps } from "./types";
 import { feedbackItems, roleKeys, helpOptionKeys } from "./constants";
+import { HoneypotField } from "./HoneypotField";
 
 interface AccordionProps extends VariantProps {
   expandedAccordion: number | null;
@@ -219,6 +220,8 @@ export const AccordionVariant: React.FC<AccordionProps> = (props) => {
 
   return (
     <form onSubmit={props.onSubmit} className="space-y-4">
+      <HoneypotField value={props.honeypot} onChange={props.onHoneypotChange} />
+
       <div className="space-y-2">
         {sections.map((section, idx) => (
           <div key={idx} className="rounded-lg overflow-hidden border border-gray-200 bg-white/80 backdrop-blur-sm">

--- a/apps/site-2026/src/components/Feedback/HoneypotField.tsx
+++ b/apps/site-2026/src/components/Feedback/HoneypotField.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+interface HoneypotFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/**
+ * Honeypot (trap field) to filter out bots.
+ *
+ * The field is not visible to humans, but is present in the DOM and appears to the parser
+ * like a regular "name" text field. Bots filling everything out
+ * will leave the value in it -this is a sign of automatic sending.
+ *
+ * Important: DO NOT use type="hidden" /display:none /visibility:hidden -
+ * many bots can skip such fields. We take it off the screen.
+ * Styles are set inline so that the field does not break due to CSS changes.
+ */
+export const HoneypotField: React.FC<HoneypotFieldProps> = ({ value, onChange }) => (
+  <div
+    aria-hidden="true"
+    style={{
+      position: "absolute",
+      left: "-9999px",
+      top: "auto",
+      width: "1px",
+      height: "1px",
+      overflow: "hidden",
+    }}
+  >
+    <label htmlFor="feedback-name-field">Name</label>
+    <input
+      id="feedback-name-field"
+      type="text"
+      name="name"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      tabIndex={-1}
+      autoComplete="off"
+    />
+  </div>
+);

--- a/apps/site-2026/src/components/Feedback/PageVariant.tsx
+++ b/apps/site-2026/src/components/Feedback/PageVariant.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { VariantProps } from "./types";
 import { feedbackItems, roleKeys, helpOptionKeys } from "./constants";
+import { HoneypotField } from "./HoneypotField";
 
 export const PageVariant: React.FC<VariantProps> = (props) => {
   return (
     <form onSubmit={props.onSubmit} className="space-y-6">
+      <HoneypotField value={props.honeypot} onChange={props.onHoneypotChange} />
+
       {/* Q0: Personal Data */}
       <div className="rounded-lg bg-white/80 backdrop-blur-sm p-6 shadow-sm border border-gray-100">
         <div className="mb-4">

--- a/apps/site-2026/src/components/Feedback/WizardVariant.tsx
+++ b/apps/site-2026/src/components/Feedback/WizardVariant.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { VariantProps } from "./types";
 import { feedbackItems, roleKeys, helpOptionKeys } from "./constants";
+import { HoneypotField } from "./HoneypotField";
 
 interface WizardProps extends VariantProps {
   currentStep: number;
@@ -324,6 +325,8 @@ export const WizardVariant: React.FC<WizardProps> = (props) => {
 
   return (
     <form onSubmit={handleFinish} onKeyDown={handleFormKeyDown} className="space-y-6">
+      <HoneypotField value={props.honeypot} onChange={props.onHoneypotChange} />
+
       <div className="rounded-lg bg-white/80 backdrop-blur-sm p-6 shadow-sm border border-gray-100">
         {questions[props.currentStep - 1].render()}
       </div>

--- a/apps/site-2026/src/components/Feedback/types.ts
+++ b/apps/site-2026/src/components/Feedback/types.ts
@@ -18,6 +18,8 @@ export interface FeedbackState {
   selectedHelp: Set<string>;
   contact: string;
   q10Answer: string;
+  /** Trap field for bots. A person does not see it, the meaning is always empty. */
+  honeypot: string;
 }
 
 export interface VariantProps extends FeedbackState {
@@ -32,6 +34,7 @@ export interface VariantProps extends FeedbackState {
   onHelpToggle: (option: string) => void;
   onContactChange: (value: string) => void;
   onQ10Change: (value: string) => void;
+  onHoneypotChange: (value: string) => void;
   onSubmit: (e: React.FormEvent) => void;
   isSubmitting?: boolean;
   t: (key: string) => string;


### PR DESCRIPTION
Protection against bots using honeypot technology has been introduced. Added a hidden field that is filled by automatic scripts, but remains empty for real users.

-Added `HoneypotField` component. -Updated the `FeedbackPayload` interface to pass the honeypot value to the API. -The field has been integrated into all feedback form options: `AccordionVariant`, `PageVariant` and `WizardVariant`. -Updated the state of the `Feedback` form to control the honeypot value.